### PR TITLE
Remove hard-coded db name

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -1,5 +1,5 @@
-CREATE TABLE `wheelmap_history`.`venue_counts` ( `category` INT NOT NULL , `wheelchair` ENUM('yes','limited','no','unknown') NOT NULL , `time` DATETIME NOT NULL , `count` INT NOT NULL ) ENGINE = InnoDB;
-ALTER TABLE `wheelmap_history`.`venue_counts` ADD PRIMARY KEY (`time`, `category`, `wheelchair`);
+CREATE TABLE `venue_counts` ( `category` INT NOT NULL , `wheelchair` ENUM('yes','limited','no','unknown') NOT NULL , `time` DATETIME NOT NULL , `count` INT NOT NULL ) ENGINE = InnoDB;
+ALTER TABLE `venue_counts` ADD PRIMARY KEY (`time`, `category`, `wheelchair`);
 
 CREATE TABLE `categories` (
   `id` int(11) NOT NULL,


### PR DESCRIPTION
I was used a different db name and tripped up because the create_db.sql file specified a different one. Have just removed it.